### PR TITLE
Prevent oScannerData race condition

### DIFF
--- a/onscan.js
+++ b/onscan.js
@@ -270,7 +270,10 @@
 	     * @return boolean
 	     */
 		_validateScanCode: function(oDomElement, sScanCode){
-			var oScannerData = oDomElement.scannerDetectionData;			
+			var oScannerData = oDomElement.scannerDetectionData;
+			if (!oScannerData) {
+				return false;
+			}
 			var oOptions = oScannerData.options;
 			var iSingleScanQty = oScannerData.options.singleScanQty;
 			var iFirstCharTime = oScannerData.vars.firstCharTime;


### PR DESCRIPTION
If a link that calls 'onScan.attachTo(document)` is focused and the enter key is pressed, `_validateScanCode()` is called before onScan is attached causing a race condition. This change prevents the errors in the console.